### PR TITLE
Rebase patches to 8.5 and add patches fixing the crashing issue

### DIFF
--- a/patches/custom/hide_prefix_update_window.patch
+++ b/patches/custom/hide_prefix_update_window.patch
@@ -8,13 +8,13 @@ Subject: [PATCH] HACK: proton: wineboot: Don't show "updating prefix" window.
  1 file changed, 33 deletions(-)
 
 diff --git a/programs/wineboot/wineboot.c b/programs/wineboot/wineboot.c
-index 4a18265c1de..e7575b491b5 100644
+index 4de20705224..fd232f0199d 100644
 --- a/programs/wineboot/wineboot.c
 +++ b/programs/wineboot/wineboot.c
-@@ -1296,37 +1296,6 @@ static BOOL start_services_process(void)
+@@ -1298,37 +1298,6 @@ static BOOL start_services_process(void)
      return TRUE;
  }
- 
+
 -static INT_PTR CALLBACK wait_dlgproc( HWND hwnd, UINT msg, WPARAM wp, LPARAM lp )
 -{
 -    switch (msg)
@@ -49,15 +49,15 @@ index 4a18265c1de..e7575b491b5 100644
  static HANDLE start_rundll32( const WCHAR *inf_path, const WCHAR *install, WORD machine )
  {
      WCHAR app[MAX_PATH + ARRAY_SIZE(L"\\rundll32.exe" )];
-@@ -1477,7 +1446,6 @@ static void update_wineprefix( BOOL force )
- 
+@@ -1479,7 +1448,6 @@ static void update_wineprefix( BOOL force )
+
          if ((process = start_rundll32( inf_path, L"PreInstall", IMAGE_FILE_MACHINE_TARGET_HOST )))
          {
 -            HWND hwnd = show_wait_window();
              for (;;)
              {
                  MSG msg;
-@@ -1495,7 +1463,6 @@ static void update_wineprefix( BOOL force )
+@@ -1497,7 +1465,6 @@ static void update_wineprefix( BOOL force )
                  }
                  else while (PeekMessageW( &msg, 0, 0, 0, PM_REMOVE )) DispatchMessageW( &msg );
              }

--- a/patches/proton/03-proton-fsync_staging.patch
+++ b/patches/proton/03-proton-fsync_staging.patch
@@ -1427,10 +1427,10 @@ index 34d4c80eee5..c48a6339fee 100644
          esync_close( handle );
 
 diff --git a/dlls/ntdll/unix/sync.c b/dlls/ntdll/unix/sync.c
-index 051c672bd12..d8a8eb526a1 100644
+index 4025a7a3a2f..b7d0d68e159 100644
 --- a/dlls/ntdll/unix/sync.c
 +++ b/dlls/ntdll/unix/sync.c
-@@ -73,6 +73,7 @@
+@@ -65,6 +65,7 @@
  #include "wine/debug.h"
  #include "unix_private.h"
  #include "esync.h"
@@ -1448,9 +1448,9 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
          return esync_create_semaphore( handle, access, attr, initial, max );
 
-@@ -297,6 +297,9 @@ NTSTATUS WINAPI NtOpenSemaphore( HANDLE *handle, ACCESS_MASK access, const OBJEC
- {
-     NTSTATUS ret;
+@@ -302,6 +346,9 @@ NTSTATUS WINAPI NtOpenSemaphore( HANDLE *handle, ACCESS_MASK access, const OBJEC
+
+     *handle = 0;
 
 +    if (do_fsync())
 +        return fsync_open_semaphore( handle, access, attr );
@@ -1458,7 +1458,7 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
          return esync_open_semaphore( handle, access, attr );
 
-@@ -327,6 +327,9 @@ NTSTATUS WINAPI NtQuerySemaphore( HANDLE handle, SEMAPHORE_INFORMATION_CLASS cla
+@@ -341,6 +388,9 @@ NTSTATUS WINAPI NtQuerySemaphore( HANDLE handle, SEMAPHORE_INFORMATION_CLASS cla
 
      if (len != sizeof(SEMAPHORE_BASIC_INFORMATION)) return STATUS_INFO_LENGTH_MISMATCH;
 
@@ -1468,9 +1468,9 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
          return esync_query_semaphore( handle, info, ret_len );
 
-@@ -367,6 +367,9 @@ NTSTATUS WINAPI NtReleaseSemaphore( HANDLE handle, ULONG count, ULONG *previous
+@@ -366,6 +416,9 @@ NTSTATUS WINAPI NtReleaseSemaphore( HANDLE handle, ULONG count, ULONG *previous
  {
-     NTSTATUS ret;
+     unsigned int ret;
 
 +    if (do_fsync())
 +        return fsync_release_semaphore( handle, count, previous );
@@ -1478,9 +1478,9 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
          return esync_release_semaphore( handle, count, previous );
 
-@@ -394,6 +394,9 @@ NTSTATUS WINAPI NtCreateEvent( HANDLE *handle, ACCESS_MASK access, const OBJECT_
-     data_size_t len;
-     struct object_attributes *objattr;
+@@ -396,6 +449,9 @@ NTSTATUS WINAPI NtCreateEvent( HANDLE *handle, ACCESS_MASK access, const OBJECT_
+     *handle = 0;
+     if (type != NotificationEvent && type != SynchronizationEvent) return STATUS_INVALID_PARAMETER;
 
 +    if (do_fsync())
 +        return fsync_create_event( handle, access, attr, type, state );
@@ -1488,8 +1488,8 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
          return esync_create_event( handle, access, attr, type, state );
 
-@@ -428,6 +428,9 @@ NTSTATUS WINAPI NtOpenEvent( HANDLE *handle, ACCESS_MASK access, const OBJECT_AT
-
+@@ -427,6 +483,9 @@ NTSTATUS WINAPI NtOpenEvent( HANDLE *handle, ACCESS_MASK access, const OBJECT_AT
+     *handle = 0;
      if ((ret = validate_open_object_attributes( attr ))) return ret;
 
 +    if (do_fsync())
@@ -1498,9 +1498,9 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
          return esync_open_event( handle, access, attr );
 
-@@ -458,6 +458,9 @@ NTSTATUS WINAPI NtSetEvent( HANDLE handle, LONG *prev_state )
- {
-     NTSTATUS ret;
+@@ -453,6 +512,9 @@ NTSTATUS WINAPI NtSetEvent( HANDLE handle, LONG *prev_state )
+     /* This comment is a dummy to make sure this patch applies in the right place. */
+     unsigned int ret;
 
 +    if (do_fsync())
 +        return fsync_set_event( handle, prev_state );
@@ -1508,9 +1508,9 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
          return esync_set_event( handle );
 
-@@ -480,6 +480,9 @@ NTSTATUS WINAPI NtResetEvent( HANDLE handle, LONG *prev_state )
- {
-     NTSTATUS ret;
+@@ -476,6 +538,9 @@ NTSTATUS WINAPI NtResetEvent( HANDLE handle, LONG *prev_state )
+     /* This comment is a dummy to make sure this patch applies in the right place. */
+     unsigned int ret;
 
 +    if (do_fsync())
 +        return fsync_reset_event( handle, prev_state );
@@ -1518,9 +1518,9 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
          return esync_reset_event( handle );
 
-@@ -512,6 +512,9 @@ NTSTATUS WINAPI NtPulseEvent( HANDLE handle, LONG *prev_state )
+@@ -509,6 +574,9 @@ NTSTATUS WINAPI NtPulseEvent( HANDLE handle, LONG *prev_state )
  {
-     NTSTATUS ret;
+     unsigned int ret;
 
 +    if (do_fsync())
 +        return fsync_pulse_event( handle, prev_state );
@@ -1528,7 +1528,7 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
          return esync_pulse_event( handle );
 
-@@ -537,6 +537,9 @@ NTSTATUS WINAPI NtQueryEvent( HANDLE handle, EVENT_INFORMATION_CLASS class,
+@@ -543,6 +611,9 @@ NTSTATUS WINAPI NtQueryEvent( HANDLE handle, EVENT_INFORMATION_CLASS class,
 
      if (len != sizeof(EVENT_BASIC_INFORMATION)) return STATUS_INFO_LENGTH_MISMATCH;
 
@@ -1538,9 +1538,9 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
          return esync_query_event( handle, info, ret_len );
 
-@@ -578,6 +578,9 @@ NTSTATUS WINAPI NtCreateMutant( HANDLE *handle, ACCESS_MASK access, const OBJECT
-     data_size_t len;
-     struct object_attributes *objattr;
+@@ -573,6 +644,9 @@ NTSTATUS WINAPI NtCreateMutant( HANDLE *handle, ACCESS_MASK access, const OBJECT
+
+     *handle = 0;
 
 +    if (do_fsync())
 +        return fsync_create_mutex( handle, access, attr, owned );
@@ -1548,8 +1548,8 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
          return esync_create_mutex( handle, access, attr, owned );
 
-@@ -611,6 +611,9 @@ NTSTATUS WINAPI NtOpenMutant( HANDLE *handle, ACCESS_MASK access, const OBJECT_A
-
+@@ -603,6 +677,9 @@ NTSTATUS WINAPI NtOpenMutant( HANDLE *handle, ACCESS_MASK access, const OBJECT_A
+     *handle = 0;
      if ((ret = validate_open_object_attributes( attr ))) return ret;
 
 +    if (do_fsync())
@@ -1558,9 +1558,9 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
          return esync_open_mutex( handle, access, attr );
 
-@@ -641,6 +641,9 @@ NTSTATUS WINAPI NtReleaseMutant( HANDLE handle, LONG *prev_count )
+@@ -628,6 +705,9 @@ NTSTATUS WINAPI NtReleaseMutant( HANDLE handle, LONG *prev_count )
  {
-     NTSTATUS ret;
+     unsigned int ret;
 
 +    if (do_fsync())
 +        return fsync_release_mutex( handle, prev_count );
@@ -1568,7 +1568,7 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
          return esync_release_mutex( handle, prev_count );
 
-@@ -665,6 +665,9 @@ NTSTATUS WINAPI NtQueryMutant( HANDLE handle, MUTANT_INFORMATION_CLASS class,
+@@ -661,6 +741,9 @@ NTSTATUS WINAPI NtQueryMutant( HANDLE handle, MUTANT_INFORMATION_CLASS class,
 
      if (len != sizeof(MUTANT_BASIC_INFORMATION)) return STATUS_INFO_LENGTH_MISMATCH;
 
@@ -1578,7 +1578,7 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
          return esync_query_mutex( handle, info, ret_len );
 
-@@ -1286,6 +1286,13 @@ NTSTATUS WINAPI NtWaitForMultipleObjects( DWORD count, const HANDLE *handles, BO
+@@ -1470,6 +1553,13 @@ NTSTATUS WINAPI NtWaitForMultipleObjects( DWORD count, const HANDLE *handles, BO
 
      if (!count || count > MAXIMUM_WAIT_OBJECTS) return STATUS_INVALID_PARAMETER_1;
 
@@ -1592,7 +1592,7 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
      {
          NTSTATUS ret = esync_wait_objects( count, handles, wait_any, alertable, timeout );
-@@ -1323,6 +1323,9 @@ NTSTATUS WINAPI NtSignalAndWaitForSingleObject( HANDLE signal, HANDLE wait,
+@@ -1502,6 +1592,9 @@ NTSTATUS WINAPI NtSignalAndWaitForSingleObject( HANDLE signal, HANDLE wait,
      select_op_t select_op;
      UINT flags = SELECT_INTERRUPTIBLE;
 
@@ -1602,7 +1602,7 @@ index 051c672bd12..d8a8eb526a1 100644
      if (do_esync())
          return esync_signal_and_wait( signal, wait, alertable, timeout );
 
-@@ -1348,7 +1348,24 @@ NTSTATUS WINAPI NtYieldExecution(void)
+@@ -1535,7 +1628,24 @@ NTSTATUS WINAPI NtYieldExecution(void)
  NTSTATUS WINAPI NtDelayExecution( BOOLEAN alertable, const LARGE_INTEGER *timeout )
  {
      /* if alertable, we need to query the server */

--- a/patches/proton/04-proton-LAA_staging.patch
+++ b/patches/proton/04-proton-LAA_staging.patch
@@ -6,27 +6,20 @@ Subject: [PATCH] ntdll/loader: add support for overriding
 
 Signed-off-by: Steven Noonan <steven@valvesoftware.com>
 ---
- dlls/kernel32/heap.c           |  9 ++++++++-
- dlls/ntdll/ntdll.spec          |  1 +
- dlls/ntdll/unix/server.c       |  3 ++-
+ dlls/kernel32/heap.c           |  7 ++++++-
+ dlls/ntdll/ntdll.spec          |  3 +++
+ dlls/ntdll/unix/loader.c       |  1 +
+ dlls/ntdll/unix/server.c       |  4 ++--
  dlls/ntdll/unix/unix_private.h |  2 ++
- dlls/ntdll/unix/virtual.c      | 13 +++++++++++++
- 5 files changed, 26 insertions(+), 2 deletions(-)
+ dlls/ntdll/unix/virtual.c      | 12 ++++++++++++
+ include/winternl.h             |  3 ++-
+ 7 files changed, 28 insertions(+), 4 deletions(-)
 
 diff --git a/dlls/kernel32/heap.c b/dlls/kernel32/heap.c
-index b7bd6f5f91d..fef060e9c22 100644
+index 1ec2f5cce0d..f3e10460e7a 100644
 --- a/dlls/kernel32/heap.c
 +++ b/dlls/kernel32/heap.c
-@@ -44,6 +44,8 @@ WINE_DEFAULT_DEBUG_CHANNEL(globalmem);
-
- static HANDLE systemHeap;   /* globally shared heap */
-
-+extern BOOL CDECL __wine_needs_override_large_address_aware(void);
-+
-
- /***********************************************************************
-  *           HEAP_CreateSystemHeap
-@@ -544,6 +546,10 @@ VOID WINAPI GlobalMemoryStatus( LPMEMORYSTATUS lpBuffer )
+@@ -425,6 +425,10 @@ VOID WINAPI GlobalMemoryStatus( LPMEMORYSTATUS lpBuffer )
  #ifndef _WIN64
      IMAGE_NT_HEADERS *nt = RtlImageNtHeader( GetModuleHandleW(0) );
  #endif
@@ -37,7 +30,7 @@ index b7bd6f5f91d..fef060e9c22 100644
 
      /* Because GlobalMemoryStatus is identical to GlobalMemoryStatusEX save
         for one extra field in the struct, and the lack of a bug, we simply
-@@ -584,7 +590,8 @@ VOID WINAPI GlobalMemoryStatus( LPMEMORYSTATUS lpBuffer )
+@@ -463,7 +467,8 @@ VOID WINAPI GlobalMemoryStatus( LPMEMORYSTATUS lpBuffer )
 
      /* values are limited to 2Gb unless the app has the IMAGE_FILE_LARGE_ADDRESS_AWARE flag */
      /* page file sizes are not limited (Adobe Illustrator 8 depends on this) */
@@ -48,24 +41,36 @@ index b7bd6f5f91d..fef060e9c22 100644
          if (lpBuffer->dwTotalPhys > MAXLONG) lpBuffer->dwTotalPhys = MAXLONG;
          if (lpBuffer->dwAvailPhys > MAXLONG) lpBuffer->dwAvailPhys = MAXLONG;
 diff --git a/dlls/ntdll/ntdll.spec b/dlls/ntdll/ntdll.spec
-index ca427c46c04..10327373959 100644
+index d5f6737e1aa..c9af898afb5 100644
 --- a/dlls/ntdll/ntdll.spec
 +++ b/dlls/ntdll/ntdll.spec
-@@ -1625,6 +1625,9 @@
+@@ -1711,6 +1711,9 @@
  @ cdecl -norelay __wine_dbg_output(str)
  @ cdecl -norelay __wine_dbg_strdup(str)
 
 +# Virtual memory
-+@ cdecl -syscall __wine_needs_override_large_address_aware()
++@ stdcall -syscall __wine_needs_override_large_address_aware()
 +
  # Version
  @ cdecl wine_get_version()
  @ cdecl wine_get_build_id()
+diff --git a/dlls/ntdll/unix/loader.c b/dlls/ntdll/unix/loader.c
+index 50446fddbbc..bbbb7baacde 100644
+--- a/dlls/ntdll/unix/loader.c
++++ b/dlls/ntdll/unix/loader.c
+@@ -359,6 +359,7 @@ static void * const syscalls[] =
+     NtWriteFileGather,
+     NtWriteVirtualMemory,
+     NtYieldExecution,
++    __wine_needs_override_large_address_aware,
+     wine_nt_to_unix_file_name,
+     wine_unix_to_nt_file_name,
+ };
 diff --git a/dlls/ntdll/unix/server.c b/dlls/ntdll/unix/server.c
-index 7236f0acb83..e34abd88093 100644
+index 97be02fbc1d..91f442a2078 100644
 --- a/dlls/ntdll/unix/server.c
 +++ b/dlls/ntdll/unix/server.c
-@@ -1471,8 +1471,8 @@ void server_init_process_done(void)
+@@ -1665,8 +1665,8 @@ void server_init_process_done(void)
  #ifdef __APPLE__
      send_server_task_port();
  #endif
@@ -77,32 +82,31 @@ index 7236f0acb83..e34abd88093 100644
      /* Install signal handlers; this cannot be done earlier, since we cannot
       * send exceptions to the debugger before the create process event that
 diff --git a/dlls/ntdll/unix/unix_private.h b/dlls/ntdll/unix/unix_private.h
-index c3ad0a41098..e0326f88a21 100644
+index 326c9c8f9eb..b629a9abda2 100644
 --- a/dlls/ntdll/unix/unix_private.h
 +++ b/dlls/ntdll/unix/unix_private.h
-@@ -470,4 +470,6 @@ static inline int ntdll_wcsnicmp( const WCHAR *str1, const WCHAR *str2, int n )
- #define towupper(c)        ntdll_towupper(c)
- #define towlower(c)        ntdll_towlower(c)
+@@ -505,4 +505,6 @@ static inline NTSTATUS map_section( HANDLE mapping, void **ptr, SIZE_T *size, UL
+                                0, NULL, size, ViewShare, 0, protect );
+ }
 
-+BOOL CDECL __wine_needs_override_large_address_aware(void);
++BOOL WINAPI __wine_needs_override_large_address_aware(void);
 +
  #endif /* __NTDLL_UNIX_PRIVATE_H */
 diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
-index 1337e2de861..200a777eb5c 100644
+index e393f313a8c..d14ade38406 100644
 --- a/dlls/ntdll/unix/virtual.c
 +++ b/dlls/ntdll/unix/virtual.c
-@@ -3420,6 +3420,19 @@ void CDECL virtual_release_address_space(void)
-     server_leave_uninterrupted_section( &virtual_mutex, &sigset );
+@@ -3442,6 +3442,18 @@ static BOOL is_inside_thread_stack( void *ptr, struct thread_stack_info *stack )
+     return ((char *)ptr > stack->start && (char *)ptr <= stack->end);
  }
 
-+BOOL CDECL __wine_needs_override_large_address_aware(void)
++BOOL WINAPI __wine_needs_override_large_address_aware(void)
 +{
 +    static int needs_override = -1;
 +
 +    if (needs_override == -1)
 +    {
 +        const char *str = getenv( "WINE_LARGE_ADDRESS_AWARE" );
-+
 +        needs_override = !str || atoi(str) == 1;
 +    }
 +    return needs_override;
@@ -110,25 +114,16 @@ index 1337e2de861..200a777eb5c 100644
 +
 
  /***********************************************************************
-  *           virtual_set_large_address_space
---
-2.26.2
+  *           grow_thread_stack
+diff --git a/include/winternl.h b/include/winternl.h
+index ed0e51bae24..de31c8b5c4d 100644
+--- a/include/winternl.h
++++ b/include/winternl.h
+@@ -4756,6 +4756,7 @@ NTSYSAPI NTSTATUS  WINAPI RtlLargeIntegerToChar(const ULONGLONG *,ULONG,ULONG,PC
 
-From 67150fb21e93e2a1d40047355de3c8c7ff2d73ca Mon Sep 17 00:00:00 2001
-From: Tk-Glitch <ti3nou@gmail.com>
-Date: Wed, 1 Sep 2021 15:58:29 +0200
-Subject: Add LAA syscall to ntdll loader array following ea6308e364b669adfcb8b1e448c8b08d715bcf6d
+ /* Wine internal functions */
 
-
-diff --git a/dlls/ntdll/unix/loader.c b/dlls/ntdll/unix/loader.c
-index 75266672f0b..428e13fea1f 100644
---- a/dlls/ntdll/unix/loader.c
-+++ b/dlls/ntdll/unix/loader.c
-@@ -347,6 +349,7 @@ static void * const syscalls[] =
-     NtWriteVirtualMemory,
-     NtYieldExecution,
-     __wine_dbg_write,
-+    __wine_needs_override_large_address_aware,
-     __wine_unix_call,
-     wine_nt_to_unix_file_name,
-     wine_server_call,
++NTSYSAPI BOOL WINAPI __wine_needs_override_large_address_aware(void);
+ NTSYSAPI NTSTATUS WINAPI wine_nt_to_unix_file_name( const OBJECT_ATTRIBUTES *attr, char *nameA, ULONG *size,
+                                                     UINT disposition );
+ NTSYSAPI NTSTATUS WINAPI wine_unix_to_nt_file_name( const char *name, WCHAR *buffer, ULONG *size );

--- a/patches/proton/49-proton_QPC-update-replace.patch
+++ b/patches/proton/49-proton_QPC-update-replace.patch
@@ -46,9 +46,9 @@ index db7baff269f..f869b8a4e89 100644
 --- a/programs/wineboot/wineboot.c
 +++ b/programs/wineboot/wineboot.c
 @@ -82,6 +82,8 @@
- 
+
  WINE_DEFAULT_DEBUG_CHANNEL(wineboot);
- 
+
 +#define TICKSPERSEC        10000000
 +
  extern BOOL shutdown_close_windows( BOOL force );
@@ -57,7 +57,7 @@ index db7baff269f..f869b8a4e89 100644
 @@ -241,15 +243,173 @@ static void initialize_xstate_features(struct _KUSER_SHARED_DATA *data)
      TRACE("XSAVE feature 2 %#x, %#x, %#x, %#x.\n", regs[0], regs[1], regs[2], regs[3]);
  }
- 
+
 +static UINT64 read_tsc_frequency( BOOL has_rdtscp )
 +{
 +    UINT64 freq = 0;
@@ -208,11 +208,11 @@ index db7baff269f..f869b8a4e89 100644
 +}
 +
  #else
- 
+
  static void initialize_xstate_features(struct _KUSER_SHARED_DATA *data)
  {
  }
- 
+
 +static void initialize_qpc_features( struct _KUSER_SHARED_DATA *data, UINT64 *tsc_frequency )
 +{
 +    data->QpcBypassEnabled = 0;
@@ -223,7 +223,7 @@ index db7baff269f..f869b8a4e89 100644
 +}
 +
  #endif
- 
+
 -static void create_user_shared_data(void)
 +static void create_user_shared_data( UINT64 *tsc_frequency )
  {
@@ -231,22 +231,22 @@ index db7baff269f..f869b8a4e89 100644
      RTL_OSVERSIONINFOEXW version;
 @@ -336,6 +496,7 @@ static void create_user_shared_data(void)
      data->ActiveGroupCount = 1;
- 
+
      initialize_xstate_features( data );
 +    initialize_qpc_features( data, tsc_frequency );
- 
+
      UnmapViewOfFile( data );
  }
 @@ -647,7 +808,7 @@ static void create_bios_key( HKEY system_key )
  }
- 
+
  /* create the volatile hardware registry keys */
 -static void create_hardware_registry_keys(void)
 +static void create_hardware_registry_keys( UINT64 tsc_frequency )
  {
      unsigned int i;
      HKEY hkey, system_key, cpu_key, fpu_key;
-@@ -884,12 +884,15 @@ static void create_hardware_registry_keys( UINT64 tsc_frequency )
+@@ -738,13 +899,16 @@ static void create_hardware_registry_keys(void)
          if (!RegCreateKeyExW( cpu_key, numW, 0, NULL, REG_OPTION_VOLATILE,
                                KEY_ALL_ACCESS, NULL, &hkey, NULL ))
          {
@@ -256,25 +256,26 @@ index db7baff269f..f869b8a4e89 100644
              RegSetValueExW( hkey, L"FeatureSet", 0, REG_DWORD, (BYTE *)&sci.ProcessorFeatureBits, sizeof(DWORD) );
              set_reg_value( hkey, L"Identifier", id );
              /* TODO: report ARM properly */
-             set_reg_value( hkey, L"ProcessorNameString", namestr );
+             RegSetValueExA( hkey, "ProcessorNameString", 0, REG_SZ, (const BYTE *)name_buffer,
+                             strlen( (char *)name_buffer ) + 1 );
              set_reg_value( hkey, L"VendorIdentifier", vendorid );
 -            RegSetValueExW( hkey, L"~MHz", 0, REG_DWORD, (BYTE *)&power_info[i].MaxMhz, sizeof(DWORD) );
 +            RegSetValueExW( hkey, L"~MHz", 0, REG_DWORD, (BYTE *)&tsc_freq_mhz, sizeof(DWORD) );
              RegCloseKey( hkey );
          }
          if (sci.ProcessorArchitecture != PROCESSOR_ARCHITECTURE_ARM &&
-@@ -1680,6 +1844,7 @@ int __cdecl main( int argc, char *argv[] )
+@@ -1733,6 +1897,7 @@ int __cdecl main( int argc, char *argv[] )
      BOOL end_session, force, init, kill, restart, shutdown, update;
      HANDLE event;
      OBJECT_ATTRIBUTES attr;
 +    UINT64 tsc_frequency = 0;
-     UNICODE_STRING nameW;
+     UNICODE_STRING nameW = RTL_CONSTANT_STRING( L"\\KernelObjects\\__wineboot_event" );
      BOOL is_wow64;
- 
+
 @@ -1765,8 +1930,8 @@ int __cdecl main( int argc, char *argv[] )
- 
+
      ResetEvent( event );  /* in case this is a restart */
- 
+
 -    create_user_shared_data();
 -    create_hardware_registry_keys();
 +    create_user_shared_data( &tsc_frequency );

--- a/patches/protonprep-LoL.sh
+++ b/patches/protonprep-LoL.sh
@@ -12,16 +12,16 @@
     git clean -xdf
 
     echo "applying staging patches"
-    ../wine-staging/patches/patchinstall.sh DESTDIR="." --all
+    ../wine-staging/staging/patchinstall.py DESTDIR="." --all
 
     echo "clock monotonic"
     patch -Np1 < ../patches/proton/01-proton-use_clock_monotonic.patch
 
-    echo "applying fsync patches"
-    patch -Np1 < ../patches/proton/03-proton-fsync_staging.patch
-
-    echo "proton futex waitv patches"
-    patch -Np1 < ../patches/proton/57-fsync_futex_waitv.patch
+    # Client won't launch with fsync patches
+    # echo "applying fsync patches"
+    # patch -Np1 < ../patches/proton/03-proton-fsync_staging.patch
+    # echo "proton futex waitv patches"
+    # patch -Np1 < ../patches/proton/57-fsync_futex_waitv.patch
 
     echo "LAA"
     patch -Np1 < ../patches/proton/04-proton-LAA_staging.patch
@@ -29,27 +29,17 @@
     echo "proton QPC performance patch"
     patch -Np1 < ../patches/proton/49-proton_QPC-update-replace.patch
 
-    echo "proton LFH performance patch"
-    patch -Np1 < ../patches/wine-hotfixes/LoL/lfh-non-proton-pre-needed.patch
-    patch -Np1 < ../patches/proton/50-proton_LFH.patch
-
-    echo "update vulkan to 1.3 for dxvk-master support"
-    patch -Np1 < ../patches/winevulkan/1.2.203.patch
-    patch -Np1 < ../patches/winevulkan/1.3.204.patch
-    patch -Np1 < ../patches/winevulkan/1.3-support.patch
-    patch -Np1 < ../patches/winevulkan/1.3-fix-prototype-mismatch.patch
-    patch -Np1 < ../patches/winevulkan/1.3-add-support-win32-long-types.patch
+    # Doesn't apply
+    # echo "proton LFH performance patch"
+    # patch -Np1 < ../patches/wine-hotfixes/LoL/lfh-non-proton-pre-needed.patch
+    # patch -Np1 < ../patches/proton/50-proton_LFH.patch
 
     echo "LoL fixes"
-    patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-6.17+-syscall-fix.patch
-    patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-abi.vsyscall32-alternative_patch_by_using_a_fake_cs_segment.patch
     patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-broken-client-update-fix.patch
-    patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-launcher-client-connectivity-fix-0001-ws2_32-Return-a-valid-value-for-WSAIoctl-SIO_IDEAL_S.patch
-    patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-garena-childwindow.patch
     patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-client-slow-start-fix.patch
-    patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-abi-vsyscall-fix.patch
-    patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-critical-error.patch
-    patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-seh-assertion-failure.patch
+    patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-ntdll-nopguard-call_vectored_handlers.patch
+    # Doesn't seem to be needed
+    # patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-ntdll-stub-NtSetInformationThread-ThreadPriority.patch
 
     echo "Custom"
     patch -Np1 < ../patches/custom/hide_prefix_update_window.patch

--- a/patches/wine-hotfixes/LoL/LoL-6.17+-syscall-fix.patch
+++ b/patches/wine-hotfixes/LoL/LoL-6.17+-syscall-fix.patch
@@ -2,7 +2,7 @@ diff --git a/tools/winebuild/import.c b/tools/winebuild/import.c
 index c876d51f8e6..654c84de587 100644
 --- a/tools/winebuild/import.c
 +++ b/tools/winebuild/import.c
-@@ -1401,19 +1401,9 @@ void output_syscalls( DLLSPEC *spec )
+@@ -1424,19 +1424,9 @@ void output_syscalls( DLLSPEC *spec )
          switch (target.cpu)
          {
          case CPU_i386:
@@ -22,6 +22,6 @@ index c876d51f8e6..654c84de587 100644
 +            output( "\t.byte 0xb8\n" );                               /* mov eax, SYSCALL */
 +            output( "\t.long %d\n", id );
 +            output( "\t.byte 0x64,0xff,0x15,0xc0,0x00,0x00,0x00\n" ); /* call dword ptr fs:[0C0h] */
-             output( "\tret $%u\n", odp->type == TYPE_STDCALL ? get_args_size( odp ) : 0 );
+             output( "\tret $%u\n", get_args_size( odp ));
              break;
          case CPU_x86_64:

--- a/patches/wine-hotfixes/LoL/LoL-abi-vsyscall-fix.patch
+++ b/patches/wine-hotfixes/LoL/LoL-abi-vsyscall-fix.patch
@@ -2,8 +2,8 @@ diff --git a/loader/preloader.c b/loader/preloader.c
 index d88964e9c4b..1ac8b9bd16b 100644
 --- a/loader/preloader.c
 +++ b/loader/preloader.c
-@@ -1460,7 +1460,7 @@ void* wld_start( void **stack )
- 
+@@ -1463,7 +1463,7 @@ void* wld_start( void **stack )
+
      i = 0;
      /* delete sysinfo values if addresses conflict */
 -    if (is_in_preload_range( av, AT_SYSINFO ) || is_in_preload_range( av, AT_SYSINFO_EHDR ))

--- a/patches/wine-hotfixes/LoL/LoL-broken-client-update-fix.patch
+++ b/patches/wine-hotfixes/LoL/LoL-broken-client-update-fix.patch
@@ -5,17 +5,17 @@
  dlls/psapi/tests/psapi_main.c |  5 +--
  2 files changed, 71 insertions(+), 10 deletions(-)
 --- a/dlls/ntdll/unix/virtual.c
-+++ a/dlls/ntdll/unix/virtual.c
-@@ -133,6 +133,8 @@ struct file_view
-          } \
-     } while (0);
++++ b/dlls/ntdll/unix/virtual.c
+@@ -112,6 +112,8 @@ struct file_view
+     unsigned int  protect;       /* protection for all pages at allocation time and SEC_* flags */
+ };
 
 +#define SYMBOLIC_LINK_QUERY 0x0001
 +
  /* per-page protection flags */
  #define VPROT_READ       0x01
  #define VPROT_WRITE      0x02
-@@ -4273,34 +4275,96 @@ static NTSTATUS get_working_set_ex( HANDLE process, LPCVOID addr,
+@@ -4466,34 +4468,96 @@ static NTSTATUS get_working_set_ex( HANDLE process, LPCVOID addr,
      return STATUS_SUCCESS;
  }
 
@@ -70,12 +70,12 @@
 +    return status;
 +}
 +
- static NTSTATUS get_memory_section_name( HANDLE process, LPCVOID addr,
-                                          MEMORY_SECTION_NAME *info, SIZE_T len, SIZE_T *ret_len )
+ static unsigned int get_memory_section_name( HANDLE process, LPCVOID addr,
+                                              MEMORY_SECTION_NAME *info, SIZE_T len, SIZE_T *ret_len )
  {
 +    SIZE_T current_path_len, max_path_len;
 +    WCHAR *name;
-     NTSTATUS status;
+     unsigned int status;
 
      if (!info) return STATUS_ACCESS_VIOLATION;
 +    max_path_len = len - sizeof(*info) - sizeof(WCHAR); // dont count null char
@@ -119,10 +119,10 @@
  }
 
 --- a/dlls/psapi/tests/psapi_main.c
-+++ a/dlls/psapi/tests/psapi_main.c
++++ b/dlls/psapi/tests/psapi_main.c
 @@ -471,7 +471,6 @@ static void test_GetMappedFileName(void)
      ret = GetMappedFileNameA(GetCurrentProcess(), base, map_name, sizeof(map_name));
-     ok(ret, "GetMappedFileName error %d\n", GetLastError());
+     ok(ret, "GetMappedFileName error %ld\n", GetLastError());
      ok(ret > strlen(device_name), "map_name should be longer than device_name\n");
 -    todo_wine
      ok(memcmp(map_name, device_name, strlen(device_name)) == 0, "map name does not start with a device name: %s\n", map_name);
@@ -138,7 +138,7 @@
 
 @@ -490,7 +488,6 @@ static void test_GetMappedFileName(void)
      ret = GetMappedFileNameA(GetCurrentProcess(), base + 0x2000, map_name, sizeof(map_name));
-     ok(ret, "GetMappedFileName error %d\n", GetLastError());
+     ok(ret, "GetMappedFileName error %ld\n", GetLastError());
      ok(ret > strlen(device_name), "map_name should be longer than device_name\n");
 -    todo_wine
      ok(memcmp(map_name, device_name, strlen(device_name)) == 0, "map name does not start with a device name: %s\n", map_name);
@@ -147,11 +147,10 @@
 @@ -566,7 +563,7 @@ static void test_GetProcessImageFileName(void)
      {
          /* Windows returns 2*strlen-1 */
-         ok(ret >= strlen(szImgPath), "szImgPath=\"%s\" ret=%d\n", szImgPath, ret);
+         ok(ret >= strlen(szImgPath), "szImgPath=\"%s\" ret=%ld\n", szImgPath, ret);
 -        todo_wine ok(!strcmp(szImgPath, szMapPath), "szImgPath=\"%s\" szMapPath=\"%s\"\n", szImgPath, szMapPath);
 +        ok(!strcmp(szImgPath, szMapPath), "szImgPath=\"%s\" szMapPath=\"%s\"\n", szImgPath, szMapPath);
      }
 
      SetLastError(0xdeadbeef);
 --
-

--- a/patches/wine-hotfixes/LoL/LoL-client-slow-start-fix.patch
+++ b/patches/wine-hotfixes/LoL/LoL-client-slow-start-fix.patch
@@ -1,11 +1,11 @@
 diff --git a/dlls/ws2_32/socket.c b/dlls/ws2_32/socket.c
-index 3d0c2deca35..b0c03d992d4 100644
+index e8a04e2e714..650a5866372 100644
 --- a/dlls/ws2_32/socket.c
 +++ b/dlls/ws2_32/socket.c
-@@ -2516,6 +2516,17 @@ int WINAPI select( int count, fd_set *read_ptr, fd_set *write_ptr,
- 
+@@ -2768,6 +2768,17 @@ int WINAPI select( int count, fd_set *read_ptr, fd_set *write_ptr,
+
      TRACE( "read %p, write %p, except %p, timeout %p\n", read_ptr, write_ptr, except_ptr, timeout );
- 
+
 +    static int is_RCS = -1;
 +    if (is_RCS < 0) {
 +        is_RCS = GetModuleHandleA(NULL) == GetModuleHandleA("RiotClientServices.exe");
@@ -18,5 +18,5 @@ index 3d0c2deca35..b0c03d992d4 100644
 +    }
 +
      if (!(sync_event = get_sync_event())) return -1;
- 
+
      if (read_ptr) poll_count += read_ptr->fd_count;

--- a/patches/wine-hotfixes/LoL/LoL-launcher-client-connectivity-fix-0001-ws2_32-Return-a-valid-value-for-WSAIoctl-SIO_IDEAL_S.patch
+++ b/patches/wine-hotfixes/LoL/LoL-launcher-client-connectivity-fix-0001-ws2_32-Return-a-valid-value-for-WSAIoctl-SIO_IDEAL_S.patch
@@ -13,13 +13,13 @@ Signed-off-by: Alistair Leslie-Hughes <leslie_alistair@hotmail.com>
  4 files changed, 61 insertions(+), 1 deletion(-)
 
 diff --git a/dlls/ntdll/unix/socket.c b/dlls/ntdll/unix/socket.c
-index 2e79b9baa0f..6d92a087850 100644
+index ac351a17a70..8adf2256337 100644
 --- a/dlls/ntdll/unix/socket.c
 +++ b/dlls/ntdll/unix/socket.c
-@@ -1424,6 +1424,37 @@ NTSTATUS sock_ioctl( HANDLE handle, HANDLE event, PIO_APC_ROUTINE apc, void *apc
-             break;
+@@ -1728,6 +1728,37 @@ NTSTATUS sock_ioctl( HANDLE handle, HANDLE event, PIO_APC_ROUTINE apc, void *apc
+             return STATUS_SUCCESS;
          }
- 
+
 +        case IOCTL_AFD_WINE_SEND_BACKLOG_QUERY:
 +        {
 +            int proto;
@@ -55,13 +55,13 @@ index 2e79b9baa0f..6d92a087850 100644
          {
              int value, ret;
 diff --git a/dlls/ws2_32/socket.c b/dlls/ws2_32/socket.c
-index 2db441bee3c..dd9759c5580 100644
+index e8a04e2e714..e3175327fe9 100644
 --- a/dlls/ws2_32/socket.c
 +++ b/dlls/ws2_32/socket.c
-@@ -1997,6 +1997,23 @@ INT WINAPI WSAIoctl(SOCKET s, DWORD code, LPVOID in_buff, DWORD in_size, LPVOID
-         return ret ? -1 : 0;
+@@ -2370,6 +2370,23 @@ INT WINAPI WSAIoctl(SOCKET s, DWORD code, LPVOID in_buff, DWORD in_size, LPVOID
+         return 0;
      }
- 
+
 +    case SIO_IDEAL_SEND_BACKLOG_QUERY:
 +    {
 +        DWORD ret;
@@ -83,10 +83,10 @@ index 2db441bee3c..dd9759c5580 100644
      {
          DWORD ret;
 diff --git a/dlls/ws2_32/tests/sock.c b/dlls/ws2_32/tests/sock.c
-index 02713a7c625..b87aef07b52 100644
+index bcccaef9bc6..16bb4042705 100644
 --- a/dlls/ws2_32/tests/sock.c
 +++ b/dlls/ws2_32/tests/sock.c
-@@ -5962,8 +5962,9 @@ static void test_WSASendTo(void)
+@@ -7188,8 +7188,9 @@ static void test_WSASendTo(void)
      struct sockaddr_in addr, ret_addr;
      char buf[12] = "hello world";
      WSABUF data_buf;
@@ -94,10 +94,10 @@ index 02713a7c625..b87aef07b52 100644
 +    DWORD bytesSent, size;
      int ret, len;
 +    ULONG backlog = 0;
- 
+
      addr.sin_family = AF_INET;
      addr.sin_port = htons(139);
-@@ -5999,6 +6000,11 @@ static void test_WSASendTo(void)
+@@ -7225,6 +7226,11 @@ static void test_WSASendTo(void)
      ok(!ret, "got error %u\n", WSAGetLastError());
      ok(ret_addr.sin_family == AF_INET, "got family %u\n", ret_addr.sin_family);
      ok(ret_addr.sin_port, "expected nonzero port\n");
@@ -107,20 +107,20 @@ index 02713a7c625..b87aef07b52 100644
 +       "WSAIoctl() failed: %d/%d\n", ret, WSAGetLastError());
 +    closesocket(s);
  }
- 
- static DWORD WINAPI recv_thread(LPVOID arg)
-@@ -6039,6 +6045,7 @@ static void test_WSARecv(void)
+
+ struct recv_thread_apc_param
+@@ -7304,6 +7310,7 @@ static void test_WSARecv(void)
      DWORD dwret;
      BOOL bret;
      HANDLE thread, event = NULL, io_port;
 +    ULONG backlog = 0, size;
- 
+
      tcp_socketpair(&src, &dest);
- 
-@@ -6187,6 +6194,10 @@ static void test_WSARecv(void)
- 
+
+@@ -7469,6 +7476,10 @@ static void test_WSARecv(void)
+
      CloseHandle(io_port);
- 
+
 +    iret = WSAIoctl(src, SIO_IDEAL_SEND_BACKLOG_QUERY, NULL, 0, &backlog, sizeof(backlog), &size, NULL, NULL);
 +    ok(!iret, "WSAIoctl() failed: %d/%d\n", iret, WSAGetLastError());
 +    ok(backlog == 0x10000, "got %08x\n", backlog);
@@ -129,17 +129,17 @@ index 02713a7c625..b87aef07b52 100644
      if (server != INVALID_SOCKET)
          closesocket(server);
 diff --git a/include/wine/afd.h b/include/wine/afd.h
-index 3b8bdcb9e5d..ef4bfa97897 100644
+index 788adb4a495..a9f8644870b 100644
 --- a/include/wine/afd.h
 +++ b/include/wine/afd.h
-@@ -238,6 +238,7 @@ struct afd_get_events_params
- #define IOCTL_AFD_WINE_SET_IP_RECVTTL                   WINE_AFD_IOC(294)
- #define IOCTL_AFD_WINE_GET_IP_RECVTOS                   WINE_AFD_IOC(295)
+@@ -285,6 +285,7 @@ C_ASSERT( sizeof(struct afd_get_events_params) == 56 );
  #define IOCTL_AFD_WINE_SET_IP_RECVTOS                   WINE_AFD_IOC(296)
-+#define IOCTL_AFD_WINE_SEND_BACKLOG_QUERY               WINE_AFD_IOC(297)
- 
- struct afd_create_params
+ #define IOCTL_AFD_WINE_GET_SO_EXCLUSIVEADDRUSE          WINE_AFD_IOC(297)
+ #define IOCTL_AFD_WINE_SET_SO_EXCLUSIVEADDRUSE          WINE_AFD_IOC(298)
++#define IOCTL_AFD_WINE_SEND_BACKLOG_QUERY               WINE_AFD_IOC(299)
+
+ struct afd_iovec
  {
--- 
+--
 2.33.0
 

--- a/patches/wine-hotfixes/LoL/LoL-ntdll-nopguard-call_vectored_handlers.patch
+++ b/patches/wine-hotfixes/LoL/LoL-ntdll-nopguard-call_vectored_handlers.patch
@@ -1,0 +1,14 @@
+diff --git a/dlls/ntdll/exception.c b/dlls/ntdll/exception.c
+index fc3e8982a98..a975e5c897a 100644
+--- a/dlls/ntdll/exception.c
++++ b/dlls/ntdll/exception.c
+@@ -168,7 +168,9 @@ LONG call_vectored_handlers( EXCEPTION_RECORD *rec, CONTEXT *context )
+
+         TRACE( "calling handler at %p code=%lx flags=%lx\n",
+                func, rec->ExceptionCode, rec->ExceptionFlags );
++        __asm__ __volatile__(".rept 16 ; nop ; .endr");
+         ret = func( &except_ptrs );
++        __asm__ __volatile__(".rept 16 ; nop ; .endr");
+         TRACE( "handler at %p returned %lx\n", func, ret );
+
+         RtlEnterCriticalSection( &vectored_handlers_section );

--- a/patches/wine-hotfixes/LoL/LoL-ntdll-stub-NtSetInformationThread-ThreadPriority.patch
+++ b/patches/wine-hotfixes/LoL/LoL-ntdll-stub-NtSetInformationThread-ThreadPriority.patch
@@ -1,0 +1,18 @@
+diff --git a/dlls/ntdll/unix/thread.c b/dlls/ntdll/unix/thread.c
+index d56962e1721..87fdf2634b9 100644
+--- a/dlls/ntdll/unix/thread.c
++++ b/dlls/ntdll/unix/thread.c
+@@ -2402,9 +2402,12 @@ NTSTATUS WINAPI NtSetInformationThread( HANDLE handle, THREADINFOCLASS class,
+         WARN("Unimplemented class ThreadPriorityBoost.\n");
+         return STATUS_SUCCESS;
+
++    case ThreadPriority:
++        WARN("Unimplemented ThreadPriority\n");
++        return STATUS_SUCCESS;
++
+     case ThreadBasicInformation:
+     case ThreadTimes:
+-    case ThreadPriority:
+     case ThreadDescriptorTableEntry:
+     case ThreadEventPair_Reusable:
+     case ThreadPerformanceCount:


### PR DESCRIPTION
Changelog:
* Rebase proton patches for wine staging 8.5.
* Disable fsync patches that don't work with the current league client.
* Disable LFH patch that doesn't seem to apply.
* Rebase some of the older LoL patches.
* Add new LoL patches that fix the crashing issue: https://github.com/kyechou/leagueoflegends/issues/83.
* Disable older 32-bit LoL patches that aren't needed anymore.

I've tested it by applying `./patches/protonprep-LoL.sh` on top of `wine-8.5`. The result is at https://github.com/kyechou/wine/tree/4e1bc4e69d1d7a2a114923afa424a8314ec240a2.