### PR TITLE
Port changes from #10 to GE-LoL 7.0

### DIFF
--- a/patches/protonprep-LoL.sh
+++ b/patches/protonprep-LoL.sh
@@ -17,11 +17,11 @@
     echo "clock monotonic"
     patch -Np1 < ../patches/proton/01-proton-use_clock_monotonic.patch
 
-    echo "applying fsync patches"
-    patch -Np1 < ../patches/proton/03-proton-fsync_staging.patch
-
-    echo "proton futex waitv patches"
-    patch -Np1 < ../patches/proton/57-fsync_futex_waitv.patch
+    # Client won't launch with fsync patches
+    # echo "applying fsync patches"
+    # patch -Np1 < ../patches/proton/03-proton-fsync_staging.patch
+    # echo "proton futex waitv patches"
+    # patch -Np1 < ../patches/proton/57-fsync_futex_waitv.patch
 
     echo "LAA"
     patch -Np1 < ../patches/proton/04-proton-LAA_staging.patch
@@ -32,7 +32,7 @@
     echo "proton LFH performance patch"
     patch -Np1 < ../patches/wine-hotfixes/LoL/lfh-non-proton-pre-needed.patch
     patch -Np1 < ../patches/proton/50-proton_LFH.patch
-    
+
     echo "update vulkan to 1.3 for dxvk-master support"
     patch -Np1 < ../patches/winevulkan/1.2.203.patch
     patch -Np1 < ../patches/winevulkan/1.3.204.patch
@@ -41,14 +41,12 @@
     patch -Np1 < ../patches/winevulkan/1.3-add-support-win32-long-types.patch
 
     echo "LoL fixes"
-    patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-6.17+-syscall-fix.patch
-    patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-abi.vsyscall32-alternative_patch_by_using_a_fake_cs_segment.patch
     patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-broken-client-update-fix.patch
     patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-launcher-client-connectivity-fix-0001-ws2_32-Return-a-valid-value-for-WSAIoctl-SIO_IDEAL_S.patch
-    patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-garena-childwindow.patch
     patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-client-slow-start-fix.patch
-    patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-abi-vsyscall-fix.patch
-    
+    patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-seh-assertion-failure.patch
+    patch -Np1 < ../patches/wine-hotfixes/LoL/LoL-ntdll-nopguard-call_vectored_handlers.patch
+
     echo "Custom"
     patch -Np1 < ../patches/custom/hide_prefix_update_window.patch
 

--- a/patches/wine-hotfixes/LoL/LoL-ntdll-nopguard-call_vectored_handlers.patch
+++ b/patches/wine-hotfixes/LoL/LoL-ntdll-nopguard-call_vectored_handlers.patch
@@ -1,0 +1,14 @@
+diff --git a/dlls/ntdll/exception.c b/dlls/ntdll/exception.c
+index c3714e8369b..ee00d97d5aa 100644
+--- a/dlls/ntdll/exception.c
++++ b/dlls/ntdll/exception.c
+@@ -168,7 +168,9 @@ LONG call_vectored_handlers( EXCEPTION_RECORD *rec, CONTEXT *context )
+ 
+         TRACE( "calling handler at %p code=%x flags=%x\n",
+                func, rec->ExceptionCode, rec->ExceptionFlags );
++        __asm__ __volatile__(".rept 16 ; nop ; .endr");
+         ret = func( &except_ptrs );
++        __asm__ __volatile__(".rept 16 ; nop ; .endr");
+         TRACE( "handler at %p returned %x\n", func, ret );
+ 
+         RtlEnterCriticalSection( &vectored_handlers_section );

--- a/patches/wine-hotfixes/LoL/LoL-seh-assertion-failure.patch
+++ b/patches/wine-hotfixes/LoL/LoL-seh-assertion-failure.patch
@@ -1,0 +1,59 @@
+diff --git a/dlls/ntdll/signal_x86_64.c b/dlls/ntdll/signal_x86_64.c
+index 7e77329363c..e47b7fd94ca 100644
+--- a/dlls/ntdll/signal_x86_64.c
++++ b/dlls/ntdll/signal_x86_64.c
+@@ -655,13 +655,22 @@ __ASM_GLOBAL_FUNC( KiUserApcDispatcher,
+  *
+  * FIXME: not binary compatible
+  */
+-void WINAPI KiUserCallbackDispatcher( ULONG id, void *args, ULONG len )
++void WINAPI user_callback_dispatcher( ULONG id, void *args, ULONG len )
+ {
+     NTSTATUS (WINAPI *func)(void *, ULONG) = ((void **)NtCurrentTeb()->Peb->KernelCallbackTable)[id];
+
+     RtlRaiseStatus( NtCallbackReturn( NULL, 0, func( args, len )));
+ }
+
++__ASM_GLOBAL_FUNC( KiUserCallbackDispatcher,
++                  "movq 0x28(%rsp), %rdx\n\t"
++                  "movl 0x30(%rsp), %ecx\n\t"
++                  "movl 0x34(%rsp), %r8d\n\t"
++                  "andq $0xFFFFFFFFFFFFFFF0, %rsp\n\t"
++                  __ASM_SEH(".seh_endprologue\n\t")
++                  "call "
++                  __ASM_NAME("user_callback_dispatcher") "\n\t"
++                  "int3")
+
+ static ULONG64 get_int_reg( CONTEXT *context, int reg )
+ {
+diff --git a/dlls/ntdll/unix/signal_x86_64.c b/dlls/ntdll/unix/signal_x86_64.c
+index 9a46b4a50b0..b91b986d94c 100644
+--- a/dlls/ntdll/unix/signal_x86_64.c
++++ b/dlls/ntdll/unix/signal_x86_64.c
+@@ -2318,8 +2318,17 @@ NTSTATUS WINAPI KeUserModeCallback( ULONG id, const void *args, ULONG len, void
+     {
+         struct syscall_frame *frame = amd64_thread_data()->syscall_frame;
+         void *args_data = (void *)((frame->rsp - len) & ~15);
++        struct {
++            void *args;
++            ULONG id;
++            ULONG len;
++        } *params = (void *)((ULONG_PTR)args_data - 0x18);
++
+
+         memcpy( args_data, args, len );
++        params->args = args_data;
++        params->id = id;
++        params->len = len;
+
+         callback_frame.frame.rcx           = id;
+         callback_frame.frame.rdx           = (ULONG_PTR)args;
+@@ -2328,7 +2337,7 @@ NTSTATUS WINAPI KeUserModeCallback( ULONG id, const void *args, ULONG len, void
+         callback_frame.frame.fs            = fs32_sel;
+         callback_frame.frame.gs            = ds64_sel;
+         callback_frame.frame.ss            = ds64_sel;
+-        callback_frame.frame.rsp           = (ULONG_PTR)args_data - 0x28;
++        callback_frame.frame.rsp           = (ULONG_PTR)params - 0x28;
+         callback_frame.frame.rip           = (ULONG_PTR)pKiUserCallbackDispatcher;
+         callback_frame.frame.eflags        = 0x200;
+         callback_frame.frame.restore_flags = CONTEXT_CONTROL | CONTEXT_INTEGER;


### PR DESCRIPTION
Changelog:

* Disable fsync patches which don't work with the current league client.
* Add new LoL patches that fix the crashing issue: https://github.com/kyechou/leagueoflegends/issues/83.
* Disable older 32-bit LoL patches that aren't needed anymore.

I've tested it by applying `./patches/protonprep-LoL.sh` on top of `wine-7.0`. The result is at https://github.com/kyechou/wine/tree/2ca9119230f4b6c962a9d07c6b17b806ac5184a8.

My own test result:
* It's working without any issue.
* There's no post-game hanging/blank client issue as described in https://github.com/kyechou/leagueoflegends/issues/92.
* The default log output (without verbose/debug flags) only contains the following type of error messages (which should be harmless), without the unhandled page faults and other errors that we observed with 8.5.
```
err:seh:dispatch_exception unknown exception (code=c0000420) raised
```